### PR TITLE
Add Docker Ansible role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# ansible-docker
+
+This repository contains an Ansible role for installing Docker.
+
+See [docs/index.md](docs/index.md) for documentation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,40 @@
+Docker Role
+===========
+
+This role installs Docker on Debian, Ubuntu and RHEL based systems using the official Docker repositories. It follows best practices from the Docker documentation.
+
+Requirements
+------------
+
+Ansible 2.12 or higher.
+
+Role Variables
+--------------
+
+```yaml
+docker_compose_plugin: true   # install docker-compose plugin
+docker_user: docker           # user created to run docker
+docker_uid: 997               # uid for docker user
+docker_group: docker          # group for docker
+docker_gid: 997               # gid for docker group
+```
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: docker
+```
+
+License
+-------
+
+MIT

--- a/docker/defaults/main.yml
+++ b/docker/defaults/main.yml
@@ -1,0 +1,7 @@
+#SPDX-License-Identifier: MIT-0
+---
+docker_compose_plugin: true
+docker_user: docker
+docker_uid: 997
+docker_group: docker
+docker_gid: 997

--- a/docker/handlers/main.yml
+++ b/docker/handlers/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for docker

--- a/docker/meta/main.yml
+++ b/docker/meta/main.yml
@@ -1,0 +1,40 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  namespace: codex
+  role_name: docker
+  author: Codex Bot
+  description: Install Docker using official repositories
+  company: Codex
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: MIT
+
+  min_ansible_version: '2.12'
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags:
+    - docker
+    - container
+    - system
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/docker/molecule/default/converge.yml
+++ b/docker/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: docker

--- a/docker/molecule/default/molecule.yml
+++ b/docker/molecule/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: debian
+    image: debian:12
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+  - name: ubuntu
+    image: ubuntu:22.04
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+  - name: rhel
+    image: quay.io/centos/centos:stream9
+    command: /sbin/init
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible

--- a/docker/tasks/main.yml
+++ b/docker/tasks/main.yml
@@ -1,0 +1,103 @@
+#SPDX-License-Identifier: MIT-0
+---
+# Install Docker on Debian/Ubuntu
+- name: Install Docker on Debian/Ubuntu
+  when: ansible_os_family == 'Debian'
+  block:
+    - name: Install prerequisite packages
+      apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+        update_cache: yes
+
+    - name: Add Docker GPG key
+      get_url:
+        url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+        dest: /usr/share/keyrings/docker-archive-keyring.gpg
+        mode: '0644'
+
+    - name: Add Docker repository
+      apt_repository:
+        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+        state: present
+
+    - name: Install Docker packages
+      apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+        update_cache: yes
+      when: docker_compose_plugin
+
+    - name: Install Docker packages without compose
+      apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+        state: present
+        update_cache: yes
+      when: not docker_compose_plugin
+
+# Install Docker on RHEL
+- name: Install Docker on RHEL
+  when: ansible_os_family == 'RedHat'
+  block:
+    - name: Install dnf plugins
+      package:
+        name: dnf-plugins-core
+        state: present
+
+    - name: Add Docker repository
+      get_url:
+        url: https://download.docker.com/linux/centos/docker-ce.repo
+        dest: /etc/yum.repos.d/docker-ce.repo
+
+    - name: Install Docker packages
+      package:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+      when: docker_compose_plugin
+
+    - name: Install Docker packages without compose
+      package:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+        state: present
+      when: not docker_compose_plugin
+
+# Configure user and service
+- name: Create docker group
+  group:
+    name: "{{ docker_group }}"
+    gid: "{{ docker_gid }}"
+    state: present
+
+- name: Create docker user
+  user:
+    name: "{{ docker_user }}"
+    uid: "{{ docker_uid }}"
+    group: "{{ docker_group }}"
+    state: present
+
+- name: Ensure Docker service is running
+  service:
+    name: docker
+    state: started
+    enabled: true

--- a/docker/tests/inventory
+++ b/docker/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/docker/tests/test.yml
+++ b/docker/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - docker

--- a/docker/vars/main.yml
+++ b/docker/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Docker Ansible Role
+
+This documentation describes how to use the included Ansible role to install Docker on supported systems. It is intended for GitHub Pages.
+
+Refer to [README](../docker/README.md) for variables and example usage.


### PR DESCRIPTION
## Summary
- add a Docker role that installs Docker via official repositories
- expose variables for compose plugin and UID/GID
- include Molecule scenario for Debian, Ubuntu and RHEL
- add GitHub Pages docs

## Testing
- `molecule test -s default` *(fails: Docker server unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_6862bbdc7794832595fb10253cf50d2b