### PR TITLE
Fix docker role compatibility and add test improvements

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,6 +17,7 @@ docker_user: docker           # user created to run docker
 docker_uid: 997               # uid for docker user
 docker_group: docker          # group for docker
 docker_gid: 997               # gid for docker group
+docker_manage_service: true   # start and enable docker service
 ```
 
 Dependencies

--- a/docker/defaults/main.yml
+++ b/docker/defaults/main.yml
@@ -5,3 +5,4 @@ docker_user: docker
 docker_uid: 997
 docker_group: docker
 docker_gid: 997
+docker_manage_service: true

--- a/docker/tasks/main.yml
+++ b/docker/tasks/main.yml
@@ -14,15 +14,16 @@
         update_cache: yes
 
     - name: Add Docker GPG key
-      get_url:
-        url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
-        dest: /usr/share/keyrings/docker-archive-keyring.gpg
-        mode: '0644'
+      shell: >-
+        curl -fsSL https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      args:
+        creates: /usr/share/keyrings/docker-archive-keyring.gpg
 
     - name: Add Docker repository
-      apt_repository:
-        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
-        state: present
+      copy:
+        dest: /etc/apt/sources.list.d/docker.list
+        content: |
+          deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
 
     - name: Install Docker packages
       apt:
@@ -57,9 +58,11 @@
         state: present
 
     - name: Add Docker repository
-      get_url:
-        url: https://download.docker.com/linux/centos/docker-ce.repo
-        dest: /etc/yum.repos.d/docker-ce.repo
+      command:
+        cmd: >-
+          curl -fsSL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
+      args:
+        creates: /etc/yum.repos.d/docker-ce.repo
 
     - name: Install Docker packages
       package:
@@ -101,3 +104,4 @@
     name: docker
     state: started
     enabled: true
+  when: docker_manage_service | bool

--- a/docker/tests/test.yml
+++ b/docker/tests/test.yml
@@ -2,5 +2,6 @@
 ---
 - hosts: localhost
   remote_user: root
+  connection: local
   roles:
     - docker


### PR DESCRIPTION
## Summary
- fix gpg key installation on modern Python by using curl & gpg
- add repository file via copy instead of apt_repository
- allow skipping service management with `docker_manage_service` variable
- document new variable
- run tests locally

## Testing
- `ansible-playbook docker/tests/test.yml -i docker/tests/inventory -e 'ansible_python_interpreter=/usr/bin/python3 ansible_distribution=Ubuntu ansible_distribution_release=jammy ansible_os_family=Debian docker_gid=9999 docker_uid=9999' -e docker_manage_service=false`

------
https://chatgpt.com/codex/tasks/task_b_6862bf2055988325a261f5b78fb1a377